### PR TITLE
Reimplement useEffect

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ import {
   createUseState,
   creatSvelteReduxStore,
 } from 'svelte-redux-store'; //import this line
-import { onMount } from 'svelte';
 
 export type AppState = ReturnType<typeof rootReducers>;
 
@@ -70,7 +69,9 @@ export const { useState } = createUseState();
 // import {useState} from 'svelte-redux-store';
 
 // create useEffect (if you want)
-export const { useEffect } = createUseEffect(onMount);
+export const { useEffect } = createUseEffect();
+// OR
+// import {useEffect} from 'svelte-redux-store';
 ```
 
 Remark: If you use rollup.js. Please see note in below
@@ -281,11 +282,11 @@ export default rootReducers;
 
   let value;
 
-  $: useEffect(() => {
+  useEffect(() => {
     if ($isOpen) {
       value = $count * 2;
     }
-  }, [$isOpen, $count]);
+  }, [isOpen, count]);
 </script>
 
 <div class="app">

--- a/src/createUseEffect.ts
+++ b/src/createUseEffect.ts
@@ -1,13 +1,52 @@
-export function createUseEffect(onMount: (fn: () => any) => void) {
-  return function useEffect(fn: () => void, params: any[]) {
-    function onChange(...params: any[]): void {
-      fn();
-    }
+import { onMount, beforeUpdate, afterUpdate } from "svelte";
+import type { Readable } from "svelte/store";
 
-    if (!params.length) {
-      return onMount(fn);
-    }
+export function createUseEffect() {
+  return function useEffect(fn: () => void | undefined | (() => void), deps?: Readable<unknown>[]) {
+    const depsVal = deps ? ([] as unknown[]) : undefined; // Save values of readable dependency stores
 
-    return onChange(...params);
-  };
+    let isMounted = false;
+
+    let unsub: void | undefined | (() => void); // Effect's cleanup callback
+
+    let previousDepsVal: unknown[] | undefined; // Snapshot of values of readable dependency stores
+
+    onMount(() => {
+      isMounted = true;
+      const unsubscribeDeps = deps?.map((d, i) =>
+        d.subscribe(v => {
+          if (depsVal) depsVal[i] = v;
+        })
+      ) // listen changes of readable dependency stores
+      checkDepsChange();
+      unsub = fn(); // initial run of effect happens when mounted, just like React
+      return () => {
+        unsub?.();
+        unsubscribeDeps?.forEach(u => u());
+      }
+    });
+
+    beforeUpdate(() => {
+      if (!isMounted) return; // This makes sure the first effect runs when onMount, like React
+      if (checkDepsChange()) unsub?.();
+    });
+
+    afterUpdate(() => {
+      if (checkDepsChange()) unsub = fn();
+    });
+
+    function checkDepsChange(): boolean {
+      if (!depsVal) return true; // No deps mean always change
+
+      const currentDepsVal = [...depsVal];
+      if (currentDepsVal.length !== previousDepsVal?.length) true;
+      for (let i = 0; i < currentDepsVal.length; i++) {
+        const curr = currentDepsVal[i];
+        const last = previousDepsVal?.[i];
+        if (!Object.is(curr, last)) return true; // Detects change
+      }
+      previousDepsVal = currentDepsVal;
+      return false; // no change
+    }
+  }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -63,7 +63,9 @@ export function createUseState() {
 
 export const { useState } = createUseState();
 
-export function createUseEffect(onMount: (fn: () => any) => void) {
-  const useEffect = createNewUseEffect(onMount);
+export function createUseEffect() {
+  const useEffect = createNewUseEffect();
   return { useEffect };
 }
+
+export const { useEffect } = createUseEffect();


### PR DESCRIPTION
As said by `React`'s official document:

> useEffect is to run some additional code after React has updated the DOM
[https://reactjs.org/docs/hooks-effect.html#example-using-hooks](https://reactjs.org/docs/hooks-effect.html#example-using-hooks)

`useEffect` should be used as a side-effect after render instead of triggering render.

Besides, like `React`,  `useEffect` should start working only after onMount like `React`'s `componentDidMount`.

This PR reimplemented `useEffect` in a more React-like style.

before:
```
  const [isOpen, setIsOpen] = useState(false);
  const count = store.selector((state: AppState) => state.count.count);

  $: useEffect(() => {
    if ($isOpen) {
      value = $count * 2;
    }
  }, [$isOpen, $count]);
```

after:
```
  const [isOpen, setIsOpen] = useState(false);
  const count = store.selector((state: AppState) => state.count.count);

  useEffect(() => { // without `$` label to trigger rerun
    if ($isOpen) {
      value = $count * 2;
    }
  }, [isOpen, count]); // use `Readable` as dependency directly here
```

For case like no specified dependency or empty array as dependency

only once on mount:
```
  const [isOpen, setIsOpen] = useState(false);
  const count = store.selector((state: AppState) => state.count.count);

  useEffect(() => {
    if ($isOpen) {
      value = $count * 2;
    }
  }, []);
```

rerun everytime component updates
```
  const [isOpen, setIsOpen] = useState(false);
  const count = store.selector((state: AppState) => state.count.count);

  useEffect(() => {
    if ($isOpen) {
      value = $count * 2;
    }
  });
```