### PR TITLE
fix Readable from Redux, fix useStore Type error

### DIFF
--- a/src/components/Provider.svelte
+++ b/src/components/Provider.svelte
@@ -1,25 +1,13 @@
 <script lang="ts">
   import type { Store } from 'redux';
   import { setContext } from 'svelte';
-  import { readable } from 'svelte/store';
+  import { readableFromReduxStore } from '../createBindReduxStore';
   import type { StoreContext } from '../interfaces/StoreContext';
   import { storeKey } from '../key';
 
   export let store: Store;
 
-  const data = readable(store.getState(), (set) => {
-    let currentState: any;
-
-    const unsubscribe = store.subscribe(() => {
-      const nextState = store.getState();
-      if (nextState !== currentState) {
-        currentState = nextState;
-        set(store.getState());
-      }
-    });
-
-    return unsubscribe;
-  });
+  const data = readableFromReduxStore(store);
 
   setContext<StoreContext>(storeKey, { store, data });
 </script>

--- a/src/createStoreFromContext.ts
+++ b/src/createStoreFromContext.ts
@@ -15,7 +15,7 @@ export function createStoreFromContext() {
       invalidate?: Invalidator<TState> | undefined
     ) => Unsubscriber;
     dispatch: TypedDispatch<TState>;
-    selector: <TState, TSelected>(
+    selector: <TSelected>(
       selector: (state: TState) => TSelected
     ) => State$<TSelected>;
   } {

--- a/src/createSubscribe.ts
+++ b/src/createSubscribe.ts
@@ -2,14 +2,14 @@ import { onDestroy } from 'svelte';
 import type { Readable } from 'svelte/store';
 
 export function createSubscribe<TState = unknown>(store: Readable<TState>) {
-  function dataSubscribe<TState>(fn: (value: TState) => void) {
+  function dataSubscribe(fn: (value: TState) => void) {
     // @ts-ignore
     const unsubscribe = store.subscribe(fn);
 
     onDestroy(unsubscribe);
   }
 
-  return function useSubscribe<TState>(fn: (value: TState) => void) {
+  return function useSubscribe(fn: (value: TState) => void) {
     if (process.env.NODE_ENV !== 'production') {
       if (!fn) {
         throw new Error(`You must pass a fn to useSubscribe`);


### PR DESCRIPTION
####  1. Fixed a bug in creating Svelte `Readable` store from Redux `Store`, which causes `Readable` unsynced with `Store`
Svelte `Readable` starts running it's self-mutating callback function only when it receives first subscriber.
[https://svelte.dev/tutorial/readable-stores](https://svelte.dev/tutorial/readable-stores)

When a `readable` is created inside `Provider` and saved into `context`, the `start` callback of `readable` will not be called until `readable` gets subscribed by its child. However, the state of Redux `Store` may changed before `start` being called, which caused the subsciber receiving stale state.

This PR fixed this by setting newest state every time `start` being called.

#### 2. Fixed Typing error of `useStore`