### PR TITLE
Add useLayoutEffect, cleaner useEffect

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ export default rootReducers;
     // useDispatch,
     // useFeatureSelector
     useEffect,
+    useLayoutEffect,
     // useSelector,
     // useState,
     // useStore,
@@ -278,6 +279,10 @@ export default rootReducers;
 
   useEffect(() => {
     alert('useEffect onMount');
+  }, []);
+
+  useLayoutEffect(() => {
+    alert('useLayoutEffect before DOM update')
   }, []);
 
   let value;

--- a/src/createUseLayoutEffect.ts
+++ b/src/createUseLayoutEffect.ts
@@ -1,0 +1,31 @@
+import { beforeUpdate, onDestroy } from "svelte";
+import type { Readable } from "svelte/store";
+import { compareEffectDeps } from "./createUseEffect";
+
+export function createUseLayoutEffect() {
+  return function useLayoutEffect(fn: () => void | undefined | (() => void), deps?: Readable<unknown>[]) {
+    const depsVal = deps ? ([] as unknown[]) : undefined;
+
+    let unsub: void | undefined | (() => void);
+
+    let previousDepsVal: unknown[] | undefined;
+
+    const unsubscribeDeps = deps?.map((d, i) =>
+      d.subscribe(v => {
+        if (depsVal) depsVal[i] = v;
+      })
+    ); // listen changes of readable dependency stores
+
+    beforeUpdate(() => {
+      if (compareEffectDeps(depsVal, previousDepsVal)) {
+        unsub = fn()
+        previousDepsVal = depsVal ? [...depsVal] : undefined
+      };
+    });
+
+    onDestroy(() => {
+      unsub?.();
+      unsubscribeDeps?.forEach(u => u());
+    })
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import { createSubscribe } from './createSubscribe';
 import { createBindReduxStore } from './createBindReduxStore';
 import { createUseState as createNewUseState } from './createUseState';
 import { createUseEffect as createNewUseEffect } from './createUseEffect';
+import { createUseLayoutEffect as createNewUseLayoutEffect } from './createUseLayoutEffect';
 import { createSelectorFromContext } from './createSelectorFormContext';
 import { createDispatchFromContext } from './createDispatchFromContext';
 import { createStoreFromContext } from './createStoreFromContext';
@@ -69,3 +70,10 @@ export function createUseEffect() {
 }
 
 export const { useEffect } = createUseEffect();
+
+export function createUseLayoutEffect() {
+  const useLayoutEffect = createNewUseLayoutEffect()
+  return { useLayoutEffect }
+}
+
+export const { useLayoutEffect } = createUseLayoutEffect()


### PR DESCRIPTION
### 1. `useLayoutEffect`
Adds a new `useLayoutEffect` API, which simulates `React`'s `useLayoutEffet`.

Signature of `useLayoutEffect` is identical to `useEffect`. It just runs effect before any updates are pushed to DOM.

```
  useEffect(() => {
    alert('useEffect onMount');
  }, []);

  useLayoutEffect(() => {
    alert('useLayoutEffect before DOM update')
  }, []);
```

### 2. Fixed a bug in func comparing useEffect dependencies

### 3. Cleaner `useEffect` implementation
